### PR TITLE
Add doctype to HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -691,6 +691,7 @@ async function onBuildKitePublicLogRequest(req, res) {
   }
 
   let header = `
+    <!DOCTYPE html>
     <html>
     <head>
       <title>${build.message}</title>


### PR DESCRIPTION
Without a doctype, some browsers will use strange rendering methods (e.g. quirks mode).